### PR TITLE
replaced run-shell-command

### DIFF
--- a/gsll/src/init/init.lisp
+++ b/gsll/src/init/init.lisp
@@ -36,7 +36,7 @@
     "A wrapper for tool `gsl-config'."
     (with-input-from-string
         (s (with-output-to-string (asdf::*verbose-out*)
-             (asdf:run-shell-command "gsl-config ~s" arg)))
+             (uiop:run-program (format nil "gsl-config ~s" arg))))
       (read-line s)
       (read-line s))))
 


### PR DESCRIPTION
I replaced from asdf:run-shell-command to uiop:run-program.
Because, this kind of warning comes out.

```common-lisp
WARNING:
   DEPRECATED-FUNCTION-STYLE-WARNING: Using deprecated function ASDF/BACKWARD-INTERFACE:RUN-SHELL-COMMAND -- please update your code to use a newer API.
The docstring for this function says:
PLEASE DO NOT USE. This function is not just DEPRECATED, but also dysfunctional.
Please use UIOP:RUN-PROGRAM instead.
```